### PR TITLE
Remove http server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,7 +1,5 @@
 'use strict';
-var http = require('http');
 var util = require('util');
-var bunyan = require('bunyan');
 var assert = require('assert');
 var EventEmitter = require('events').EventEmitter;
 
@@ -18,12 +16,13 @@ function Server(options) {
 
 	this.name = options.name || 'resource_machine';
 	this.treeVersion = options.treeVersion || 'v3';
-	this.log = options.log || this._createLogger();
+	this.log = (assert.ok(options.log), options.log)
 
 	this.defaultResource = require('./resource').defaults;
 
 	this.router = new Router();
-	this.server = http.createServer(function incomingRequest(req, res) {
+
+	return function incomingRequest(req, res) {
 
 		// TODO: Do this better and more professionally.
 		request(self, req);
@@ -48,7 +47,7 @@ function Server(options) {
 		});
 
 		decisionCore.handleRequest(req, res);
-	});
+	}
 }
 util.inherits(Server, EventEmitter);
 module.exports = Server;
@@ -64,18 +63,4 @@ Server.prototype.addRoutes = function addRoutes(routes) {
 		assert.ok(util.isObject(route.resource));
 		this.addRoute(route.path, route.resource, route.context);
 	});
-};
-
-Server.prototype.listen = function listen() {
-	var args = Array.prototype.slice.call(arguments);
-	return (this.server.listen.apply(this.server, args));
-};
-
-Server.prototype.close = function close(cb) {
-	var args = Array.prototype.slice.call(arguments);
-	return (this.server.close.apply(this.server, args));
-};
-
-Server.prototype._createLogger = function _createLogger() {
-	return bunyan.createLogger({name: this.name});
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -14,6 +14,7 @@ function Server(options) {
 	var self = this;
 	if (!options) { options = {}; }
 
+  this.config = options
 	this.name = options.name || 'resource_machine';
 	this.treeVersion = options.treeVersion || 'v3';
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -16,13 +16,12 @@ function Server(options) {
 
 	this.name = options.name || 'resource_machine';
 	this.treeVersion = options.treeVersion || 'v3';
-	this.log = (assert.ok(options.log), options.log)
 
 	this.defaultResource = require('./resource').defaults;
 
 	this.router = new Router();
 
-	return function incomingRequest(req, res) {
+	this.handler = function incomingRequest(req, res) {
 
 		// TODO: Do this better and more professionally.
 		request(self, req);
@@ -41,7 +40,7 @@ function Server(options) {
 			return res.end(JSON.stringify(error.body));
 		}
 
-		req.log = self.log.child({
+		req.log = req.log.child({
 			resource: req.resource && req.resource.name,
 			requestId: req.requestId
 		});


### PR DESCRIPTION
Removing the http server lets us wrap resource-machine in express, or whatever other http server might be used as frontend. Further work to this is necessary, to abstract away the request/response idiosyncracies of different servers. That means to integrate resource-machine all you need to do is write a request handler that maps the server request and response objects to resource-machine compatible structures.
